### PR TITLE
Publicizing at http://implicit.ly and http://ls.implicit.ly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ name := "imaging"
 
 organization := "net.liftmodules"
 
+homepage := Some(url("https://github.com/liftmodules/imaging"))
+
 version := "1.4-SNAPSHOT"
 
 liftVersion <<= liftVersion ?? "2.6-SNAPSHOT"
@@ -71,3 +73,17 @@ pomExtra := (
 	 	</developer>
 	 </developers>
  )
+
+ 
+// Configuration for generating json files for publishing at http://ls.implicit.ly
+seq(lsSettings :_*)
+
+(LsKeys.tags in LsKeys.lsync) := Seq("lift", "images", "liftmodules")
+
+(description in LsKeys.lsync) := "a Lift module for providing image-related utilities."
+
+(LsKeys.ghUser in LsKeys.lsync) := Some("liftmodules")
+
+(LsKeys.ghRepo in LsKeys.lsync) := Some("imaging")
+
+(LsKeys.ghBranch in LsKeys.lsync) := Some("master")

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "net.liftmodules"
 
 homepage := Some(url("https://github.com/liftmodules/imaging"))
 
-version := "1.4-SNAPSHOT"
+version := "1.3"
 
 liftVersion <<= liftVersion ?? "2.6-SNAPSHOT"
 

--- a/notes/1.3.markdown
+++ b/notes/1.3.markdown
@@ -1,0 +1,3 @@
+#scala @liftweb
+
+* First release for Lift 2.6

--- a/notes/about.markdown
+++ b/notes/about.markdown
@@ -1,0 +1,1 @@
+**imaging** is a Lift module for providing image-related utilities.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")

--- a/src/main/ls/1.3.json
+++ b/src/main/ls/1.3.json
@@ -1,0 +1,26 @@
+{
+  "organization" : "net.liftmodules",
+  "name" : "imaging",
+  "version" : "1.3",
+  "description" : "a Lift module for providing image-related utilities.",
+  "site" : "https://github.com/liftmodules/imaging",
+  "tags" : [ "lift", "images", "liftmodules" ],
+  "docs" : "",
+  "resolvers" : [ "https://oss.sonatype.org/content/repositories/releases" ],
+  "dependencies" : [ {
+    "organization" : "net.liftweb",
+    "name" : "lift-webkit",
+    "version" : "2.6-SNAPSHOT"
+  }, {
+    "organization" : "net.liftweb",
+    "name" : "lift-util",
+    "version" : "2.6-SNAPSHOT"
+  }, {
+    "organization" : "org.apache.sanselan",
+    "name" : "sanselan",
+    "version" : "0.97-incubator"
+  } ],
+  "scalas" : [ "2.11.2", "2.10.0" ],
+  "licenses" : [ ],
+  "sbt" : false
+}


### PR DESCRIPTION
Here's what's gotta happen...
# implicit.ly blog

My first commit pertains to getting the release announced at [implicit.ly](http://implicit.ly).  You'll need to [install herald](https://github.com/n8han/herald#install) and [send n8han an email](mailto:nathan@technically.us?subject=Requesting%20implicit.ly%20publishing%20rights) to get permissions to publish to the blog.  In a nutshell, the notes I added in `notes/` will be turned into a blog post there.  The latest version (`1.3` in this case) will be at the top, and the `about.markdown` gets appended to the end.

I like adding twitter tags to the top of the revision notes because the first bit goes onto a tweet.  You of course should adjust the notes to your liking, as this is actually the first I've looked at this module. :)
# ls.implicit.ly card catalog

This one is even easier to do.  You're welcome to [read about publishing](http://ls.implicit.ly/#publishing) but because I added `ls-sbt` to the project already, you simply need to run `sbt lsync` to be done here.  This one works via the json file(s) in `src/main/ls`.  This json file is generated by `ls-sbt` by running the `lsWriteVersion` task in sbt.  Again I took a stab at what the data should be.  It is all at the bottom of the `build.sbt` file.  The data here and about the project gets written out to the ls json file.  As before, tweak all of this to your liking.

I can take care of these steps as needed. The main thing I need is for folks to look at the notes I've written, since I don't know this project as I already mentioned.  Just let me know.
